### PR TITLE
Refactoring & Outlook.com Rules Add

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.npmignore
+.gitignore
+.travis.yml
+package-lock.json
+node_modules/
+.git/

--- a/index.js
+++ b/index.js
@@ -1,37 +1,49 @@
-'use strict'
+'use strict';
 
-var isEmail = require('is-email')
+var PLUS_ONLY = /\+.*$/;
+var PLUS_AND_DOT = /\.|\+.*$/g;
+var normalizeableProviders = {
+  'gmail.com': {
+    'cut': PLUS_AND_DOT
+  },
+  'googlemail.com': {
+    'cut': PLUS_AND_DOT,
+    'aliasOf': 'gmail.com'
+  },
+  'hotmail.com': {
+    'cut': PLUS_ONLY
+  },
+  'live.com': {
+    'cut': PLUS_AND_DOT
+  },
+  'outlook.com': {
+    'cut': PLUS_ONLY
+  }
+};
 
-module.exports = function normalizeEmail(email) {
-  if (typeof email != 'string') {
-    throw new TypeError('normalize-email expects a string')
+module.exports = function normalizeEmail(eMail) {
+  if (typeof eMail != 'string') {
+    throw new TypeError('normalize-email expects a string');
   }
 
-  if (!isEmail(email)) {
-    return email
+  var email = eMail.toLowerCase();
+  var emailParts = email.split(/@/);
+
+  if (emailParts.length !== 2) {
+    return eMail;
   }
 
-  email = email.toLowerCase()
+  var username = emailParts[0];
+  var domain = emailParts[1];
 
-  var emailParts = email.split(/@/)
-  var username = emailParts[0]
-  var domain = emailParts[1]
-
-  if (isNormalizeableProvider(domain)) {
-    username = username.split('+')[0]
-
-    if(!/hotmail\.com$/.test(domain)) {
-      username = username.replace(/\./g, '')
+  if (normalizeableProviders.hasOwnProperty(domain)) {
+    if (normalizeableProviders[domain].hasOwnProperty('cut')) {
+      username = username.replace(normalizeableProviders[domain]['cut'], '');
+    }
+    if (normalizeableProviders[domain].hasOwnProperty('aliasOf')) {
+      domain = normalizeableProviders[domain]['aliasOf'];
     }
   }
 
-  if (domain == 'googlemail.com') {
-    domain = 'gmail.com'
-  }
-
-  return username + '@' + domain
-}
-
-function isNormalizeableProvider(domain) {
-  return /^hotmail\.com|gmail\.com|googlemail\.com|live\.com$/.test(domain)
+  return username + '@' + domain;
 }

--- a/index.js
+++ b/index.js
@@ -38,10 +38,10 @@ module.exports = function normalizeEmail(eMail) {
 
   if (normalizeableProviders.hasOwnProperty(domain)) {
     if (normalizeableProviders[domain].hasOwnProperty('cut')) {
-      username = username.replace(normalizeableProviders[domain]['cut'], '');
+      username = username.replace(normalizeableProviders[domain].cut, '');
     }
     if (normalizeableProviders[domain].hasOwnProperty('aliasOf')) {
-      domain = normalizeableProviders[domain]['aliasOf'];
+      domain = normalizeableProviders[domain].aliasOf;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -19,16 +19,14 @@
     "normalize",
     "gmail",
     "hotmail",
-    "live"
+    "live",
+	"outlook"
   ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/johnotander/normalize-email/issues"
   },
   "homepage": "https://github.com/johnotander/normalize-email",
-  "dependencies": {
-    "is-email": "^0.1.1"
-  },
   "devDependencies": {
     "mocha": "*"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gmail",
     "hotmail",
     "live",
-	"outlook"
+    "outlook"
   ],
   "license": "MIT",
   "bugs": {

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,13 @@ var liveEmailsToNormalize = [
   'john.otander@live.com'
 ]
 
+var outlookEmailsToNormalize = [
+  'john.otander@outlook.com',
+  'JOHN.otander@outlook.com',
+  'john.Otander+any.label@outlook.com',
+  'john.otander+foobar@outlook.com',
+]
+
 describe('normalize-email', function() {
 
   it('should normalize gmail emails', function() {
@@ -51,4 +58,11 @@ describe('normalize-email', function() {
       assert.equal(normalizeEmail(email), 'johnotander@live.com')
     })
   })
+  
+  it('should normalize outlook emails', function() {
+    outlookEmailsToNormalize.forEach(function(email) {
+      assert.equal(normalizeEmail(email), 'john.otander@outlook.com')
+    })
+  })
+  
 })


### PR DESCRIPTION
Hello! I would like to contribute to your awesome library to make it even more normalize-able!

Changes I've made:

1. Removed `is-email` dependency, as it does nothing more than checking whether e-mail matches `.*@.*\..*`, which is pretty useless for this module and can be done in a form of a simple if statement.
2. Refactored a code and an algorithm to use constants. This makes the code more extendable.
3. Added `outlook.com` provider rules.
4. Added tests for `outlook.com` provider.
5. Added `.npmignore` file which cleans unused files from being upload to npm (and downloaded to thousands of computers). Personally, I would like to also ignore `test` directory, but let it be on your own decision.

The code edits look like the whole library rewrite, but I hope everyone will benefit from this! 😄 All the original logic is preserved. I am going to link your library in my article so that's why I am proposing this changes.

Thank you!