### PR TITLE
add support for normalizing yahoo emails

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var PLUS_ONLY = /\+.*$/;
 var PLUS_AND_DOT = /\.|\+.*$/g;
+var PLUS_AND_DASH = /-.*|\+.*$/g;
 var normalizeableProviders = {
   'gmail.com': {
     'cut': PLUS_AND_DOT
@@ -18,6 +19,9 @@ var normalizeableProviders = {
   },
   'outlook.com': {
     'cut': PLUS_ONLY
+  },
+  'yahoo.com': {
+    'cut': PLUS_AND_DASH
   }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,13 @@ var outlookEmailsToNormalize = [
   'john.otander+foobar@outlook.com',
 ]
 
+var yahooEmailsToNormalize = [
+  'john.otander@yahoo.com',
+  'JOHN.otander@yahoo.com',
+  'john.Otander+any.label@yahoo.com',
+  'john.otander-foobar@yahoo.com',
+]
+
 describe('normalize-email', function() {
 
   it('should normalize gmail emails', function() {
@@ -58,11 +65,16 @@ describe('normalize-email', function() {
       assert.equal(normalizeEmail(email), 'johnotander@live.com')
     })
   })
-  
+
   it('should normalize outlook emails', function() {
     outlookEmailsToNormalize.forEach(function(email) {
       assert.equal(normalizeEmail(email), 'john.otander@outlook.com')
     })
   })
-  
+
+  it('should normalize yahoo emails', function() {
+    yahooEmailsToNormalize.forEach(function(email) {
+      assert.equal(normalizeEmail(email), 'john.otander@yahoo.com')
+    })
+  })
 })


### PR DESCRIPTION
Yahoo treats `-` like `+` is treated in the email standard.
See https://help.yahoo.com/kb/SLN3523.html